### PR TITLE
Configurable API endpoint per environment for dashboard app

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,3 +79,7 @@ gulp.task('watch', ['default'], function() {
 gulp.task('watch:test', ['test'], function() {
   gulp.watch(['./assets/js/**/*.js', './test/*.js'],['test']);
 });
+
+gulp.task('env', function() {
+  require('fs').writeFileSync('dist/__/env.js', "window.API_ENDPOINT = window.API_ENDPOINT || 'http://localhost:8080';");
+});

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -10,6 +10,7 @@
     <script type="text/javascript">
       (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
     </script>
+    <script src="__/env.js"></script>
     <script src="js/all.js"></script>
 
     <!--[if gt IE 8]><!--><link href="{{{ assetPath }}}css/govuk-template.css?0.16.0" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->


### PR DESCRIPTION
The dashboard app is now expecting a file at `./__/env.js` containing an API endpoint URL set as a variable on the window. There is a `gulp env` task to generate a sample file - not part of the build process at present.
