### PR TITLE
adding in the travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+  - docker build -t quay.io/ukhomeofficedigital/removals_dashboard:travis .


### PR DESCRIPTION
Adding in a travis yaml for the builds, so that there are some visible tests to the public, this is part of th eopen source policy. 
